### PR TITLE
Fix Taiwan name (remove "Province of China")

### DIFF
--- a/country_dialcode/not_sql/country.sql
+++ b/country_dialcode/not_sql/country.sql
@@ -209,7 +209,7 @@ INSERT INTO `dialcode_country` (`id`, `countrycode`, `iso2`, `countryprefix`, `c
 (204, 'SWE', 'SE', 46, 'Sweden'),
 (205, 'CHE', 'CH', 41, 'Switzerland'),
 (206, 'SYR', 'SY', 963, 'Syrian Arab Republic'),
-(207, 'TWN', 'TW', 886, 'Taiwan, Province Of China'),
+(207, 'TWN', 'TW', 886, 'Taiwan'),
 (208, 'TJK', 'TJ', 992, 'Tajikistan'),
 (209, 'TZA', 'TZ', 255, 'Tanzania, United Republic Of'),
 (210, 'THA', 'TH', 66, 'Thailand'),


### PR DESCRIPTION
Fix https://github.com/Star2Billing/django-country-dialcode/issues/9

In this list, Hong Kong is not even part of China. If that's the case then Taiwan shouldn't also be under province of China.